### PR TITLE
Disable layout adjustments during scrolling

### DIFF
--- a/EMPageViewController/EMPageViewController.swift
+++ b/EMPageViewController/EMPageViewController.swift
@@ -281,6 +281,10 @@ public class EMPageViewController: UIViewController, UIScrollViewDelegate {
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
+        guard !scrolling else {
+            return
+        }
+        
         self.scrollView.frame = self.view.bounds
         if self.orientationIsHorizontal {
             self.scrollView.contentSize = CGSize(width: self.view.bounds.width * 3, height: self.view.bounds.height)


### PR DESCRIPTION
I am experiencing the following scenario (bug):

1. Use selectViewController() 
2. Sometimes during the animation viewWillLayoutSubviews() is called
3. For some reasons the last call of scrollViewDidScroll() is not with the final offset (the offset is very close to the final but not exactly equal). That's why progress is not 1.0 (in my cases it is something like 0.997..) and didFinishScrollingToViewController() is never called.