### PR TITLE
Made adjustingContentOffset public to prevent issues on orientation changing, and updated example

### DIFF
--- a/EMPageViewController/EMPageViewController.swift
+++ b/EMPageViewController/EMPageViewController.swift
@@ -170,7 +170,7 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
     /// The direction the page controller is scrolling towards.
     open private(set) var navigationDirection: EMPageViewControllerNavigationDirection?
     
-    private var adjustingContentOffset = false // Flag used to prevent isScrolling delegate when shifting scrollView
+    public var adjustingContentOffset = false // Flag used to prevent isScrolling delegate when shifting scrollView
     private var loadNewAdjoiningViewControllersOnFinish = false
     private var didFinishScrollingCompletionHandler: ((_ transitionSuccessful: Bool) -> Void)?
     private var transitionAnimated = false // Used for accurate view appearance messages

--- a/Examples/Greetings-ObjC/Greetings-ObjC/RootViewController.m
+++ b/Examples/Greetings-ObjC/Greetings-ObjC/RootViewController.m
@@ -188,5 +188,26 @@
     
 }
 
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id <UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    // Code here will execute before the rotation begins.
+    // Equivalent to placing it in the deprecated method -[willRotateToInterfaceOrientation:duration:]
+    
+    // Disable scrolling in our swipe navigation to prevent layout issues.
+    [self.pageViewController.scrollView setScrollEnabled:NO];
+    self.pageViewController.adjustingContentOffset = YES;
+    NSLog(@"ROTATING WILL START");
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        
+    } completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        // Code here will execute after the rotation has finished.
+        // Equivalent to placing it in the deprecated method -[didRotateFromInterfaceOrientation:]
+        
+        // Enable scrolling once rotating finishes so we can use swipe navigation.
+        [self.pageViewController.scrollView setScrollEnabled:YES];
+        self.pageViewController.adjustingContentOffset = NO;
+        NSLog(@"ROTATING FINISHED ");
+    }];
+}
 
 @end


### PR DESCRIPTION
If I have multiple pages loaded and I rotate device, EMPageViewControllerDelegate willStartScrollingFrom delegates get called for not visible pages and messes up the UI.

- Made adjustingContentOffset public 
- Disabled scrollview scrolling and adjustingContentOffset set to false from rootViewController while orientation happens prevents issues